### PR TITLE
fraud warning test: use saucelabs.com instead of google.com

### DIFF
--- a/src/tests.es6.js
+++ b/src/tests.es6.js
@@ -55,8 +55,8 @@ tests.longWebTest = async function (driver) {
 };
 
 tests.webTestFraud = async function (driver) {
-  await driver.get("http://foo:bar@google.com");
-  await driver.waitFor(titleToMatch("Google"), 7000, 700);
+  await driver.get("http://foo:bar@saucelabs.com/test/guinea-pig");
+  await driver.waitFor(titleToMatch("I am a page title"), 7000, 700);
 };
 tests.webTestFraud.extraCaps = {safariIgnoreFraudWarning: true};
 


### PR DESCRIPTION
Some simulators got stuck in a refresh loop trying to load `foo:bar@google.com`

Replacing with `foo:bar@saucelabs.com` resolves this.

Issue: https://discussions.apple.com/thread/6556800?tstart=0