### PR TITLE
Sumologic

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,13 @@ Ultimately the app will output something like:
 
 Ultimately it gives us a good idea of which platforms are supported and how reliable they are! See `src/matrix/appium.es6.js` for more parameters.
 
+
+## Report results to Sumo Logic
+
+```bash
+./bin/runsauce.js -i tests.json -j "https://endpoint1.collection.us2.sumologic.com/...."
+```
+
 ## Building from source
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "cli-table": "^0.3.1",
     "es6-mapify": "^1.0.0",
     "lodash": "^3.3.1",
+    "logs-to-sumologic": "^1.0.2",
     "optimist": "~0.6.0",
     "prompt": "~0.2.12",
     "q": "^1.2.0",

--- a/src/main.es6.js
+++ b/src/main.es6.js
@@ -28,6 +28,7 @@ export async function runsauce (opts = null, log = true, statusFn = null) {
   if (config === null) {
     exit("Could not load config file, please run with --setup");
   }
+
   if (opts.testsuite || opts.testfile) {
     if (opts.testsuite) {
       testfile = opts.testsuite;
@@ -63,6 +64,7 @@ export async function runsauce (opts = null, log = true, statusFn = null) {
     processes: opts.processes,
     verbose: opts.verbose,
     build: opts.build,
+    sumoLogic: opts.jsonToSumo
   }, config[opts.config]), log, statusFn);
 }
 

--- a/src/matrix/utils.es6.js
+++ b/src/matrix/utils.es6.js
@@ -39,4 +39,3 @@ export function avg (arr) {
   }
   return 0;
 }
-

--- a/src/parser.es6.js
+++ b/src/parser.es6.js
@@ -213,6 +213,11 @@ export function parse (argOverride = null) {
       describe: 'Extra capabilities (JSON string, will be merged into final caps)',
       demand: false
     })
+    .options('j', {
+      alias: 'jsonToSumo',
+      describe: 'Sumo Logic collection endpoint',
+      demand: false
+    })
     .boolean(['setup', 'wait', 'help', 'shortcuts', 'tests', 'verbose']);
 
 
@@ -255,6 +260,7 @@ function mapArgs (args) {
     t: 'test',
     r: 'runs',
     e: 'extraCaps',
+    j: 'jsonToSumo',
   };
   for (let [shortcut, nameSet] of _.pairs(optMap)) {
     let name = nameSet;

--- a/src/utils.es6.js
+++ b/src/utils.es6.js
@@ -1,13 +1,11 @@
 import Sumologic from 'logs-to-sumologic';
 
 export function sendToSumo (url, logs) {
-  const sumologic = Sumologic.createClient({
-    url: url
-  });
+  const sumologic = Sumologic.createClient({url});
   return new Promise(function(resolve, reject) {
     sumologic.log(logs, function (err) {
       if (err) {
-        reject(err);
+        return reject(err);
       }
       resolve();
     });

--- a/src/utils.es6.js
+++ b/src/utils.es6.js
@@ -1,0 +1,15 @@
+import Sumologic from 'logs-to-sumologic';
+
+export function sendToSumo (url, logs) {
+  const sumologic = Sumologic.createClient({
+    url: url
+  });
+  return new Promise(function(resolve, reject) {
+    sumologic.log(logs, function (err) {
+      if (err) {
+        reject(err);
+      }
+      resolve();
+    });
+  });
+}


### PR DESCRIPTION
Users can now `-j https://sumo/collection/endpoint` to send the JSON results to sumo.

`Q.fcall` wasn't behaving with `logs-to-sumologic`, manually creating a promise.

Results include: 
`startupTime` - Session start time
`time` - Entire time of test, including session start time
`stack` - If this is null, the test was successful.

@jlipps please review. Also invited you to the demo Sumo account.