### PR TITLE
Fixing the device-orientation cap

### DIFF
--- a/lib/caps.js
+++ b/lib/caps.js
@@ -40,7 +40,7 @@ function getCaps (testSpec, eventTimings = false) {
     caps.eventTimings = true;
   }
   if (testSpec.orientation) {
-    caps['device-orientation'] = testSpec.orientation;
+    caps['deviceOrientation'] = testSpec.orientation;
   }
   if (testSpec.device) {
     caps.device = testSpec.device;

--- a/lib/caps.js
+++ b/lib/caps.js
@@ -40,7 +40,7 @@ function getCaps (testSpec, eventTimings = false) {
     caps.eventTimings = true;
   }
   if (testSpec.orientation) {
-    caps['deviceOrientation'] = testSpec.orientation;
+    caps['device-orientation'] = testSpec.orientation;
   }
   if (testSpec.device) {
     caps.device = testSpec.device;

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -56,7 +56,7 @@ let shortcutHelp = function () {
     'Platforms (-p)': platformMap,
     'Browsers (-b)': browserMap,
     'Devices (-d)': deviceMap,
-    'Orientations': orientationMap,
+    'Orientations (-o)': orientationMap,
     'Automation Names': automationNameMap,
   };
   _.each(shortcutTypes, function(map, type) {
@@ -262,7 +262,7 @@ function mapArgs (args) {
     d: ['device', deviceMap],
     m: ['automationName', automationNameMap],
     a: 'backendVersion',
-    o: 'orientation',
+    o: ['orientation', orientationMap],
     v: 'version',
     l: 'localname',
     w: 'wait',

--- a/test/parser-specs.js
+++ b/test/parser-specs.js
@@ -8,6 +8,7 @@ describe('parser', () => {
     it('should convert shortcuts in args to actual values', () => {
       mapArgs({b: 's'}).should.eql({browser: 'Safari'});
       mapArgs({p: 'm9'}).should.eql({platform: 'Mac 10.9'});
+      mapArgs({o: 'l'}).should.eql({orientation: 'landscape'});
     });
     it('should convert shortcuts for the whole arg set', () => {
       mapArgs({b: 's', p: 'm9'}).should.eql({browser: 'Safari', platform: 'Mac 10.9'});


### PR DESCRIPTION
A few changes for the orientation cap:
* Added the option for the orientations in the `--shortcuts` description. (`(-o)`)
* Adding the array of the orientationMap so it matches the docs and we can now send: `-o l` or `-o p` for landscape and portrait modes.