### PR TITLE
add possibility to change sauce endpoints

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -64,6 +64,14 @@ async function runTest (testSpec, opts, shouldLog, multiRun, statusFn) {
     driver = wd.promiseChainRemote(opts.server, opts.port);
   }
 
+  if (opts.sauceRestRoot) {
+    driver.sauceRestRoot = opts.sauceRestRoot;
+  }
+
+  if (opts.sauceTestPageRoot) {
+    driver.sauceTestPageRoot = opts.sauceTestPageRoot;
+  }
+
   // wrap test execution in try/catch so we can recover gracefully
   try {
     let startTime = Date.now();


### PR DESCRIPTION
Since we have new endpoints, like EU, it would be good to have the possibility to change the rest API endpoint and jobs urls.

For ex.: by setting:
```
"eu": {
    "server": "ondemand.eu-central-1.saucelabs.com",
    "port": 80,
    "userName": "<username>",
    "accessKey": "<access_key>",
    "sauceRestRoot": "https://eu-central-1.saucelabs.com/rest/v1",
    "sauceTestPageRoot": "https://app.eu-central-1.saucelabs.com/jobs"
},
``` 
we can easily change to which API report the failure/success of a test. 