### PR TITLE
fix: make waits conform to wd api

### DIFF
--- a/lib/tests.js
+++ b/lib/tests.js
@@ -6,12 +6,17 @@ const should = require('should');
 const Asserter = wd.asserters.Asserter;
 let tests = {};
 
+function markAssertionErrorForRetry (err) {
+  err.retriable = err instanceof should.AssertionError;
+  throw err;
+}
+
 function titleToMatch (match) {
-  return new Asserter(function (driver, cb) {
-    driver.title().then((title) => {
+  return new Asserter(function (driver) {
+    return driver.title().then((title) => {
       title.should.containEql(match);
-      return true;
-    }).nodeify(cb);
+      return title;
+    }).catch(markAssertionErrorForRetry);
   });
 }
 
@@ -19,8 +24,8 @@ function contexts () {
   return new Asserter(function (driver, cb) {
     driver.contexts().then((contexts) => {
       contexts.length.should.be.above(1);
-      return true;
-    }).nodeify(cb);
+      return contexts;
+    }).catch(markAssertionErrorForRetry);
   });
 }
 
@@ -234,7 +239,7 @@ tests.androidLoadTest = async function (driver, caps) {
 
   let args = await driver.elementById('textOptions');
   let goBtn = await driver.elementById('go');
- 
+
   await args.clear();
   await args.sendKeys(`-M 500 -v 20 -s ${Math.floor(iterations * intervalMs / 1000)}`);
 


### PR DESCRIPTION
The current implementation does not work with `wd` as it stands. Update to mark for retry, so the polling works. See examples in https://github.com/admc/wd/blob/master/examples/promise/wait-for-custom.js